### PR TITLE
support yaml anchors/references for defaults across groups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "apply-inovelli-defaults"
 ]

--- a/apply-inovelli-defaults/resources/test/config/invalid_format.yaml
+++ b/apply-inovelli-defaults/resources/test/config/invalid_format.yaml
@@ -1,0 +1,3 @@
+name: test_invalid_format
+values:
+  test: 0

--- a/apply-inovelli-defaults/resources/test/config/valid.yaml
+++ b/apply-inovelli-defaults/resources/test/config/valid.yaml
@@ -1,0 +1,5 @@
+- name: test_valid
+  condition:
+    mode: test
+  values:
+    test: 0

--- a/apply-inovelli-defaults/src/config.rs
+++ b/apply-inovelli-defaults/src/config.rs
@@ -1,9 +1,11 @@
+use anyhow::Context;
 use std::collections::{BTreeMap, HashMap};
+use std::fs::File;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-
 /// A configuration structure for this tool.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct ConfigClause {
     /// Name of the configuration clause. Logged if it matches.
     name: Option<String>,
@@ -36,5 +38,46 @@ impl ConfigClause {
         } else {
             None
         }
+    }
+}
+
+pub fn load(path: &PathBuf) -> anyhow::Result<Vec<ConfigClause>> {
+    let config_file = File::open(path).with_context(|| "Opening file")?;
+    let mut config: serde_yaml::Value = serde_yaml::from_reader(config_file)
+        .with_context(|| "Loading file, yaml may be invalid")?;
+    config.apply_merge().with_context(|| "Merging yaml")?;
+    serde_yaml::from_value(config).with_context(|| "Parsing file, unexpected format")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::*;
+
+    #[test]
+    fn valid_config() {
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("resources/test/config/valid.yaml");
+
+        let expected = vec![ConfigClause {
+            name: Some("test_valid".to_string()),
+            condition: BTreeMap::from_iter(vec![(
+                "mode".to_string(),
+                serde_json::Value::String("test".to_string()),
+            )]),
+            values: HashMap::from_iter(vec![(
+                "test".to_string(),
+                serde_json::Value::Number(serde_json::Number::from(0)),
+            )]),
+        }];
+
+        assert_eq!(load(&path).unwrap(), expected);
+    }
+
+    #[test]
+    fn invalid_config_format() {
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("resources/test/config/invalid_format.yaml");
+
+        assert!(matches!(load(&path), Err(t) if t.to_string().contains("unexpected format")));
     }
 }

--- a/apply-inovelli-defaults/src/lib.rs
+++ b/apply-inovelli-defaults/src/lib.rs
@@ -113,8 +113,8 @@ async fn read_message<'de, T: serde::de::DeserializeOwned + fmt::Debug>(
     read: &mut SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
 ) -> anyhow::Result<T> {
     let Some(next) = read.next().await else {
-            anyhow::bail!("No next message - counterparty hung up?");
-        };
+        anyhow::bail!("No next message - counterparty hung up?");
+    };
     let message = next.context("Error receiving next message")?;
     let data = message.into_data();
     let message =
@@ -146,19 +146,22 @@ impl Connection {
         real: bool,
     ) -> anyhow::Result<Self> {
         let mut read = read;
-        let Z2mInitMessage::BridgeState{..} = read_message(&mut read).await? else {
+        let Z2mInitMessage::BridgeState { .. } = read_message(&mut read).await? else {
             anyhow::bail!("Could not read init bridge state");
         };
-        let Z2mInitMessage::BridgeInfo{payload: init_messages::BridgeInfo{version}} = read_message(&mut read).await? else {
+        let Z2mInitMessage::BridgeInfo {
+            payload: init_messages::BridgeInfo { version },
+        } = read_message(&mut read).await?
+        else {
             anyhow::bail!("Could not read init bridge state");
         };
-        let Z2mInitMessage::Devices{payload: devices} = read_message(&mut read).await? else {
+        let Z2mInitMessage::Devices { payload: devices } = read_message(&mut read).await? else {
             anyhow::bail!("Could not read the bridge's devices");
         };
-        let Z2mInitMessage::Groups{} = read_message(&mut read).await? else {
+        let Z2mInitMessage::Groups {} = read_message(&mut read).await? else {
             anyhow::bail!("Could not read the bridge's groups");
         };
-        let Z2mInitMessage::Extensions{} = read_message(&mut read).await? else {
+        let Z2mInitMessage::Extensions {} = read_message(&mut read).await? else {
             anyhow::bail!("Could not read the bridge's extensions");
         };
         Ok(Self {

--- a/apply-inovelli-defaults/src/main.rs
+++ b/apply-inovelli-defaults/src/main.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 
 use anyhow::Context;
 use apply_inovelli_defaults::config;
@@ -34,14 +34,8 @@ async fn main() -> anyhow::Result<()> {
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
     tracing::debug!(cmdline = ?args, "Starting");
 
-    let config_file = File::open(&args.config_file)
-        .with_context(|| format!("Opening config file {:?}", &args.config_file))?;
-    let mut config: serde_yaml::Value = serde_yaml::from_reader(config_file)
-        .with_context(|| format!("Loading config file {:?}, yaml may be invalid", &args.config_file))?;
-    config.apply_merge()
-        .with_context(|| format!("Merging config file {:?}", &args.config_file))?;
-    let config: Vec<config::ConfigClause> = serde_yaml::from_value(config)
-        .with_context(|| format!("Parsing config file {:?}, unexpected format", &args.config_file))?;
+    let config = config::load(&args.config_file)
+        .with_context(|| format!("Loading config file {:?}", &args.config_file))?;
 
     let mut conn = apply_inovelli_defaults::Connection::connect(&args.zigbee2mqtt_url, args.real)
         .await

--- a/examples/group-defaults.yaml
+++ b/examples/group-defaults.yaml
@@ -1,0 +1,21 @@
+# Example for how to use yaml anchors and references to apply defaults across groups
+
+- name: "Global Defaults"
+  # the condition does not match anything, this group is just to hold defaults
+  condition:
+    dummy: true
+  values: &defaults
+    smartBulbMode: "Smart Bulb Mode"
+    buttonDelay: "0ms"
+    relayClick: "Enabled (Click Sound Off)"
+
+- name: "On/off switches"
+  condition:
+    outputMode: "On/Off"
+  values:
+    # use the values from above in this group
+    <<: *defaults
+    # override a default value
+    buttonDelay: "100ms"
+    # add new values too
+    periodicPowerAndEnergyReports: 600


### PR DESCRIPTION
Thanks for the awesome project! Worked great for me.

I tried to use yaml anchors/references to define defaults across groups but found that did not work (was getting `<<` as an object key). `serde_yaml` doesn't seem handle them by default. It appears you are supposed to use [apply_merge](https://docs.rs/serde_yaml/latest/serde_yaml/enum.Value.html#method.apply_merge).

So I modified the config loading to call that and added an example for how it can work. I am new to Rust and the ecosystem so please let me know if this isn't the right approach. 

Let me know what you think, thanks!